### PR TITLE
Front end work

### DIFF
--- a/src/components/AddImage.jsx
+++ b/src/components/AddImage.jsx
@@ -10,6 +10,7 @@ export default function AddWindowImage() {
   // file upload states
   const [imgSrc, setImgSrc] = useState(null);
   const [preview, setPreview] = useState(null);
+  const [verifyImage, setVerifyImage] = useState(0);
   const project = useSelector((store) => store.project);
   const currentWindowId = useSelector((store) => store.currentWindowId);
 
@@ -27,6 +28,7 @@ export default function AddWindowImage() {
     formData.append("current_window_id", currentWindowId);
     // console.log("FORMDATA", [...formData.entries()]);
     dispatch(actions.addWindowPhoto(formData));
+    setVerifyImage(null);
   };
 
   const videoConstraints = {
@@ -53,6 +55,7 @@ export default function AddWindowImage() {
   // event handler for taking a picture and updating the imgSrc state to the
   // base64 value of the image
   const capture = React.useCallback(() => {
+    setVerifyImage(true);
     const imageSrc = webcamRef.current.getScreenshot();
     setPreview(imageSrc);
     const imageBlob = dataURItoBlob(imageSrc);
@@ -62,21 +65,33 @@ export default function AddWindowImage() {
 
   return (
     <>
-      <Webcam
-        audio={false}
-        height={720}
-        ref={webcamRef}
-        screenshotFormat="image/jpeg"
-        width={1280}
-        videoConstraints={videoConstraints}
-      />
-      {preview && <img src={preview} />}
-      <Button onClick={capture} text="Capture Image">
-        {" "}
-      </Button>
-      <Button onClick={sendPhotoToServer} text="Submit">
-        {" "}
-      </Button>
+      {!preview && (
+        <Webcam
+          audio={false}
+          height={720}
+          ref={webcamRef}
+          screenshotFormat="image/jpeg"
+          width={1280}
+          videoConstraints={videoConstraints}
+        />
+      )}
+      {preview && (
+        <>
+          <p>Preview:</p>
+          <img src={preview} />
+          {verifyImage && <Button onClick={sendPhotoToServer} text="Save" />}
+          {verifyImage && (
+            <Button
+              onClick={() => {
+                setPreview(null);
+                setVerifyImage(null);
+              }}
+              text="Retake"
+            />
+          )}
+        </>
+      )}
+      {!preview && <Button onClick={capture} text="Capture Image" />}
     </>
   );
 }

--- a/src/components/FormPageInput.jsx
+++ b/src/components/FormPageInput.jsx
@@ -3,6 +3,7 @@ export default function FormPageInput({
   value,
   setValue,
   type = "text",
+  status,
 }) {
   return (
     <input
@@ -11,6 +12,7 @@ export default function FormPageInput({
       value={value}
       onChange={(event) => setValue(event.target.value)}
       className="input input-bordered mb-2"
+      disabled={false || status}
     />
   );
 }

--- a/src/page-views/FormPageAddImagesView.jsx
+++ b/src/page-views/FormPageAddImagesView.jsx
@@ -10,6 +10,7 @@ import {
   updateWindowDimensions,
   updateWindowFrame,
 } from "../store/sagas/window.saga";
+import Button from "../components/Button";
 
 export default function FormPageAddImages() {
   const dispatch = useDispatch();
@@ -48,6 +49,9 @@ export default function FormPageAddImages() {
         value={imageHeight}
         setValue={setImageHeight}
       />
+      {imageWidth && imageHeight && (
+        <Button onClick={saveDimensions} text="Save Dimensions" />
+      )}
       <FormPageButtonsContainer>
         <FormPageNavigationButtons page={4} />
       </FormPageButtonsContainer>
@@ -59,9 +63,9 @@ export default function FormPageAddImages() {
       >
         List of Window Frames
       </button>
-      <button className="btn" onClick={saveDimensions}>
+      {/* <button className="btn" onClick={saveDimensions}>
         Save Dimensions
-      </button>
+      </button> */}
       <dialog id="my_modal_3" className="modal">
         <div className="modal-box">
           <form method="dialog">

--- a/src/page-views/FormPageAddImagesView.jsx
+++ b/src/page-views/FormPageAddImagesView.jsx
@@ -56,17 +56,12 @@ export default function FormPageAddImages() {
       {imageWidth && imageHeight && !dimensionsStatus && (
         <Button onClick={saveDimensions} text="Save Dimensions" />
       )}
-      <FormPageButtonsContainer>
-        <FormPageNavigationButtons page={4} />
-      </FormPageButtonsContainer>
-
       {/* You can open the modal using document.getElementById('ID').showModal() method */}
-      <button
+      <Button
         className="btn"
         onClick={() => document.getElementById("my_modal_3").showModal()}
-      >
-        List of Window Frames
-      </button>
+        text="Click to choose desired frame"
+      ></Button>
       <dialog id="my_modal_3" className="modal">
         <div className="modal-box">
           <form method="dialog">
@@ -75,7 +70,7 @@ export default function FormPageAddImages() {
               onClick={updateFrameType}
               className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
             >
-              ✕
+              Save
             </button>
           </form>
           <h3 className="font-bold text-lg">Desired Window Frame</h3>
@@ -98,6 +93,9 @@ export default function FormPageAddImages() {
           </ul>
         </div>
       </dialog>
+      <FormPageButtonsContainer>
+        <FormPageNavigationButtons page={4} />
+      </FormPageButtonsContainer>
     </>
   );
 }

--- a/src/page-views/FormPageAddImagesView.jsx
+++ b/src/page-views/FormPageAddImagesView.jsx
@@ -18,6 +18,7 @@ export default function FormPageAddImages() {
   const [imageWidth, setImageWidth] = useState("");
   const [imageHeight, setImageHeight] = useState("");
   const [frameType, setFrameType] = useState(null);
+  const [dimensionsStatus, setDimensionsStatus] = useState(false);
 
   const frameTypes = useSelector((store) => store.frames);
   useEffect(() => {
@@ -27,6 +28,7 @@ export default function FormPageAddImages() {
   const saveDimensions = () => {
     const dimensionsToSend = { currentWindowId, imageWidth, imageHeight };
     dispatch(updateWindowDimensions(dimensionsToSend));
+    setDimensionsStatus(true);
   };
 
   const updateFrameType = () => {
@@ -43,13 +45,15 @@ export default function FormPageAddImages() {
         placeholder="Window Width"
         value={imageWidth}
         setValue={setImageWidth}
+        status={dimensionsStatus}
       />
       <FormPageInput
         placeholder="Window Height"
         value={imageHeight}
         setValue={setImageHeight}
+        status={dimensionsStatus}
       />
-      {imageWidth && imageHeight && (
+      {imageWidth && imageHeight && !dimensionsStatus && (
         <Button onClick={saveDimensions} text="Save Dimensions" />
       )}
       <FormPageButtonsContainer>
@@ -63,9 +67,6 @@ export default function FormPageAddImages() {
       >
         List of Window Frames
       </button>
-      {/* <button className="btn" onClick={saveDimensions}>
-        Save Dimensions
-      </button> */}
       <dialog id="my_modal_3" className="modal">
         <div className="modal-box">
           <form method="dialog">


### PR DESCRIPTION
This PR contains a few updates to the front end. 

- UI now displays a save or retake button after capturing an image. Save sends the image to S3 and updates the database with the path, while locking the image preview. Retake unlocks the webcam and discards the preview
- After entering both a height and width, a conditional button component will prompt the user to save the dimensions. When they confirm, the dimensions will appear as locked.
- Desired frame type now appears after the dimensions, rather than at the bottom of the page. Also adjusted the modal closing button to 'save' rather than 'x', since closing the modal dispatches the update to PUT to the database.